### PR TITLE
[Wip] Add protocol buffers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,5 +10,12 @@ scalaVersion := "2.12.8"
 
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor" % "2.5.22",
-  "com.twitter"       %% "chill-akka" % "0.9.3"
+  "com.twitter"       %% "chill-akka" % "0.9.3",
+  // https://scalapb.github.io/sbt-settings.html
+  "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf"
 )
+
+PB.targets in Compile := Seq(
+  scalapb.gen() -> (sourceManaged in Compile).value
+)
+

--- a/project/protoc.sbt
+++ b/project/protoc.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.21")
+
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.9.0-M6"

--- a/src/main/protobuf/jmh.models/protobuf.proto
+++ b/src/main/protobuf/jmh.models/protobuf.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+import "scalapb/scalapb.proto";
+
+package jmh.models;
+
+option java_package = "jmh.models";
+option java_outer_classname = "ModelForPBProtos";
+
+message ModelForPB {
+  bool a = 1;
+  int32 b = 2;
+  int32 c = 3;
+  int64 d = 4;
+  int32 e = 5 [(scalapb.field).type = "scala.math.BigDecimal"];
+  string f = 6;
+  bool g = 7;
+  string h = 8 [(scalapb.field).type = "java.time.LocalDateTime"];
+  string i = 9 [(scalapb.field).type = "java.time.OffsetDateTime"];
+
+  repeated double j = 10 [(scalapb.field).type = "scala.math.BigDecimal", (scalapb.field).collection_type="collection.Seq"];
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -3,11 +3,13 @@ akka {
     serializers {
       java = "akka.serialization.JavaSerializer"
       kryo = "com.twitter.chill.akka.AkkaSerializer"
+      proto = "jmh.serializers.ProtoBufModelSerializer"
     }
 
     serialization-bindings {
       "jmh.models.ModelForJava" = java
       "jmh.models.ModelForKryo" = kryo
+      "jmh.models.protobuf.ModelForPB" = proto
     }
   }
 }

--- a/src/main/scala/jmh/AkkaSerializerBenchmark.scala
+++ b/src/main/scala/jmh/AkkaSerializerBenchmark.scala
@@ -4,7 +4,8 @@ import java.util.concurrent.TimeUnit
 
 import akka.actor.ActorSystem
 import akka.serialization.{Serialization, SerializationExtension, Serializer}
-import jmh.models.{ModelForJava, ModelForKryo}
+import jmh.models.protobuf.ModelForPB
+import jmh.models.{ModelForJava, ModelForKryo, ModelForPBFactory}
 import org.openjdk.jmh.annotations._
 
 @State(Scope.Thread)
@@ -15,12 +16,15 @@ class AkkaSerializerBenchmark {
 
   val modelForJava: ModelForJava = ModelForJava()
   val modelForKryo: ModelForKryo = ModelForKryo()
+  val modelForPB:   ModelForPB   = ModelForPBFactory.default
 
   val serializerForJava: Serializer = serialization.findSerializerFor(modelForJava)
   val serializerForKryo: Serializer = serialization.findSerializerFor(modelForKryo)
+  val serializerForPB:   Serializer = serialization.findSerializerFor(modelForPB)
 
   val bytesForJava: Array[Byte] = serializerForJava.toBinary(modelForJava)
   val bytesForKryo: Array[Byte] = serializerForKryo.toBinary(modelForKryo)
+  val bytesForPB:   Array[Byte] = serializerForPB.toBinary(modelForPB)
 
   @Setup
   def setup(): Unit = {}
@@ -47,6 +51,13 @@ class AkkaSerializerBenchmark {
   @Benchmark
   @BenchmarkMode(Array(Mode.Throughput, Mode.AverageTime))
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  def pbSerializerBenchmark(): Unit = {
+    serializerForPB.toBinary(modelForPB)
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput, Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
   def javaDeserializerBenchmark(): Unit = {
     serializerForJava.fromBinary(bytesForJava)
   }
@@ -56,6 +67,13 @@ class AkkaSerializerBenchmark {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   def kryoDeserializerBenchmark(): Unit = {
     serializerForKryo.fromBinary(bytesForKryo)
+  }
+
+  @Benchmark
+  @BenchmarkMode(Array(Mode.Throughput, Mode.AverageTime))
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  def pbDeserializerBenchmark(): Unit = {
+    serializerForPB.fromBinary(bytesForPB)
   }
 
 }

--- a/src/main/scala/jmh/models/ModelForPBFactory.scala
+++ b/src/main/scala/jmh/models/ModelForPBFactory.scala
@@ -1,0 +1,28 @@
+package jmh.models
+
+import java.time.{LocalDateTime, OffsetDateTime}
+
+import jmh.models.protobuf.ModelForPB
+
+object ModelForPBFactory {
+  def default: ModelForPB = {
+    val decimals: Seq[BigDecimal] = Seq(
+      111.1111111111111, 111.2222222222222, 222.2222222222222, 222.3333333333333, 333.3333333333333, 333.4444444444444,
+      444.4444444444444, 444.5555555555555, 555.5555555555555, 555.6666666666666, 666.6666666666666, 666.7777777777777,
+      777.7777777777777, 777.8888888888888, 888.8888888888888, 888.9999999999999, 999.9999999999999, 999.0000000000000
+    )
+
+    ModelForPB(
+      a = true,
+      b = 1.toShort,
+      c = 1,
+      d = 1.toLong,
+      e = BigDecimal(1),
+      f = "1",
+      g = false,
+      h = LocalDateTime.now(),
+      i = OffsetDateTime.now(),
+      j = decimals
+    )
+  }
+}

--- a/src/main/scala/jmh/models/protobuf.scala
+++ b/src/main/scala/jmh/models/protobuf.scala
@@ -1,0 +1,30 @@
+package jmh.models
+
+import java.time.format.DateTimeFormatter
+import java.time.{LocalDateTime, OffsetDateTime}
+
+import scalapb.TypeMapper
+
+package object protobuf {
+
+  implicit val bigDecimalFromStringMapper =
+    TypeMapper[String, BigDecimal](s => if (s.isEmpty) BigDecimal(0) else BigDecimal(s))(_.toString())
+
+  implicit val bigDecimalFromIntMapper =
+    TypeMapper[Int, BigDecimal](BigDecimal(_))(_.toInt)
+
+  implicit val bigDecimalFromDoubleMapper =
+    TypeMapper[Double, BigDecimal](BigDecimal.valueOf)(_.toDouble)
+
+  implicit val localDateTimeMapper =
+    TypeMapper[String, LocalDateTime](s => {
+      if (s.isEmpty) LocalDateTime.MIN
+      else LocalDateTime.parse(s, DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+    })(_.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME))
+
+  implicit val offsetDateTimeMapper =
+    TypeMapper[String, OffsetDateTime](s => {
+      if (s.isEmpty) OffsetDateTime.MIN
+      else OffsetDateTime.parse(s, DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+    })(_.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME))
+}

--- a/src/main/scala/jmh/serializers/ProtoBufModelSerializer.scala
+++ b/src/main/scala/jmh/serializers/ProtoBufModelSerializer.scala
@@ -1,0 +1,22 @@
+package jmh.serializers
+
+import akka.serialization.SerializerWithStringManifest
+import jmh.models.protobuf.ModelForPB
+
+class ProtoBufModelSerializer extends SerializerWithStringManifest {
+  override def identifier: Int = 777
+
+  override def manifest(o: AnyRef): String = o.getClass.getName
+
+  override def toBinary(o: AnyRef): Array[Byte] = {
+    o match {
+      case m: ModelForPB => m.toByteArray
+    }
+  }
+
+  override def fromBinary(bytes: Array[Byte], manifest: String): AnyRef = {
+    manifest match {
+      case _ => ModelForPB.parseFrom(bytes)
+    }
+  }
+}


### PR DESCRIPTION
Protocol buffersのベンチマークを追加しました。
実行結果は下記となります。

```
> jmh:run -i 30 -wi 10 -f 1 -t 1

[info] # Run complete. Total time: 01:20:23

[info] Benchmark                                           Mode  Cnt    Score    Error   Units
[info] AkkaSerializerBenchmark.javaDeserializerBenchmark  thrpt   30   22.566 ±  0.305  ops/ms
[info] AkkaSerializerBenchmark.javaSerializerBenchmark    thrpt   30   44.762 ±  1.432  ops/ms
[info] AkkaSerializerBenchmark.kryoDeserializerBenchmark  thrpt   30  286.020 ± 14.793  ops/ms
[info] AkkaSerializerBenchmark.kryoSerializerBenchmark    thrpt   30  282.072 ±  9.955  ops/ms
[info] AkkaSerializerBenchmark.pbDeserializerBenchmark    thrpt   30  133.977 ±  4.311  ops/ms
[info] AkkaSerializerBenchmark.pbSerializerBenchmark      thrpt   30  386.709 ± 10.453  ops/ms
[info] AkkaSerializerBenchmark.javaDeserializerBenchmark   avgt   30    0.070 ±  0.021   ms/op
[info] AkkaSerializerBenchmark.javaSerializerBenchmark     avgt   30    0.023 ±  0.001   ms/op
[info] AkkaSerializerBenchmark.kryoDeserializerBenchmark   avgt   30    0.003 ±  0.001   ms/op
[info] AkkaSerializerBenchmark.kryoSerializerBenchmark     avgt   30    0.004 ±  0.001   ms/op
[info] AkkaSerializerBenchmark.pbDeserializerBenchmark     avgt   30    0.008 ±  0.001   ms/op
[info] AkkaSerializerBenchmark.pbSerializerBenchmark       avgt   30    0.003 ±  0.001   ms/op
[success] Total time: 4826 s, completed 2019/06/12 14:32:59
```

Serializerの実装は下記を参考に行いました。
https://blog.knoldus.com/protobuf-serialization-in-akka/

ScalaPBについて下記にメモを残しました。
https://komuten.rickcloud.jp/wiki/display/~naga.areab@gmail.com/ScalaPB